### PR TITLE
Fallingblock backport

### DIFF
--- a/src/main/java/rms/carpet_rms_addition/CarpetRMSAdditionSettings.java
+++ b/src/main/java/rms/carpet_rms_addition/CarpetRMSAdditionSettings.java
@@ -42,6 +42,10 @@ public final class CarpetRMSAdditionSettings {
     public static String usePortalBlacklist = "[]";
     @Rule(desc = "Stops all particle packets from being sent", category = {RMS})
     public static boolean interceptParticlePackets = false;
+    //#if MC < 11802
+    @Rule(desc = "Port the behavior of falling blocks from 1.18.2+", category = {RMS})
+    public static boolean fallingBlockBackport = false;
+    //#endif
     private static int blockLightLevel = -1;
     private static int skyLightLevel = -1;
     private static boolean keepBlockLightLevel = true;

--- a/src/main/java/rms/carpet_rms_addition/CarpetRMSAdditionSettings.java
+++ b/src/main/java/rms/carpet_rms_addition/CarpetRMSAdditionSettings.java
@@ -13,7 +13,7 @@ import net.minecraft.world.gen.Spawner;
 import java.util.List;
 import java.util.Optional;
 
-//#if MC >= 12104
+//#if MC >= 12001
 //$$ @SuppressWarnings("removal")
 //#endif
 public final class CarpetRMSAdditionSettings {

--- a/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockEntityMixin.java
@@ -1,0 +1,37 @@
+package rms.carpet_rms_addition.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.FallingBlockEntity;
+import net.minecraft.world.World;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import rms.carpet_rms_addition.CarpetRMSAdditionSettings;
+
+@Mixin(FallingBlockEntity.class)
+public abstract class FallingBlockEntityMixin extends Entity {
+    private FallingBlockEntityMixin(final EntityType<?> type, final World world) {
+        super(type, world);
+    }
+
+    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z", ordinal = 0))
+    private boolean isOf(final BlockState instance, final Block block) {
+        return !CarpetRMSAdditionSettings.fallingBlockBackport && instance.isOf(block);
+    }
+
+    @Redirect(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isClient:Z", opcode = Opcodes.GETFIELD, ordinal = 0))
+    private boolean isClient(final World instance) {
+        return CarpetRMSAdditionSettings.fallingBlockBackport || instance.isClient;
+    }
+
+    @Inject(method = "<init>(Lnet/minecraft/world/World;DDDLnet/minecraft/block/BlockState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/FallingBlockEntity;setVelocity(Lnet/minecraft/util/math/Vec3d;)V", ordinal = 0))
+    private void init(final World world, final double x, final double y, final double z, final BlockState block, final CallbackInfo ci) {
+        if (CarpetRMSAdditionSettings.fallingBlockBackport) this.setPosition(x, y, z);
+    }
+}

--- a/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockEntityMixin.java
+++ b/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockEntityMixin.java
@@ -1,18 +1,10 @@
 package rms.carpet_rms_addition.mixin;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.FallingBlockEntity;
 import net.minecraft.world.World;
-import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import rms.carpet_rms_addition.CarpetRMSAdditionSettings;
 
 @Mixin(FallingBlockEntity.class)
 public abstract class FallingBlockEntityMixin extends Entity {
@@ -20,18 +12,20 @@ public abstract class FallingBlockEntityMixin extends Entity {
         super(type, world);
     }
 
-    @Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z", ordinal = 0))
-    private boolean isOf(final BlockState instance, final Block block) {
-        return !CarpetRMSAdditionSettings.fallingBlockBackport && instance.isOf(block);
+    //#if MC < 11802
+    @org.spongepowered.asm.mixin.injection.Redirect(method = "tick", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z", ordinal = 0))
+    private boolean isOf(final net.minecraft.block.BlockState instance, final net.minecraft.block.Block block) {
+        return !rms.carpet_rms_addition.CarpetRMSAdditionSettings.fallingBlockBackport && instance.isOf(block);
     }
 
-    @Redirect(method = "tick", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isClient:Z", opcode = Opcodes.GETFIELD, ordinal = 0))
+    @org.spongepowered.asm.mixin.injection.Redirect(method = "tick", at = @org.spongepowered.asm.mixin.injection.At(value = "FIELD", target = "Lnet/minecraft/world/World;isClient:Z", opcode = org.objectweb.asm.Opcodes.GETFIELD, ordinal = 0))
     private boolean isClient(final World instance) {
-        return CarpetRMSAdditionSettings.fallingBlockBackport || instance.isClient;
+        return rms.carpet_rms_addition.CarpetRMSAdditionSettings.fallingBlockBackport || instance.isClient;
     }
 
-    @Inject(method = "<init>(Lnet/minecraft/world/World;DDDLnet/minecraft/block/BlockState;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/FallingBlockEntity;setVelocity(Lnet/minecraft/util/math/Vec3d;)V", ordinal = 0))
-    private void init(final World world, final double x, final double y, final double z, final BlockState block, final CallbackInfo ci) {
-        if (CarpetRMSAdditionSettings.fallingBlockBackport) this.setPosition(x, y, z);
+    @org.spongepowered.asm.mixin.injection.Inject(method = "<init>(Lnet/minecraft/world/World;DDDLnet/minecraft/block/BlockState;)V", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/entity/FallingBlockEntity;setVelocity(Lnet/minecraft/util/math/Vec3d;)V", ordinal = 0))
+    private void init(final World world, final double x, final double y, final double z, final net.minecraft.block.BlockState block, final org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        if (rms.carpet_rms_addition.CarpetRMSAdditionSettings.fallingBlockBackport) this.setPosition(x, y, z);
     }
+    //#endif
 }

--- a/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockMixin.java
+++ b/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockMixin.java
@@ -1,22 +1,17 @@
 package rms.carpet_rms_addition.mixin;
 
-import net.minecraft.block.BlockState;
 import net.minecraft.block.FallingBlock;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import rms.carpet_rms_addition.CarpetRMSAdditionSettings;
 
 import java.util.Random;
 
 @Mixin(FallingBlock.class)
 public abstract class FallingBlockMixin {
-    @Inject(method = "scheduledTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/FallingBlock;configureFallingBlockEntity(Lnet/minecraft/entity/FallingBlockEntity;)V", ordinal = 0))
-    private void scheduleTick(final BlockState state, final ServerWorld world, final BlockPos pos, final Random random, final CallbackInfo ci) {
-        if (CarpetRMSAdditionSettings.fallingBlockBackport)
+    //#if MC < 11802
+    @org.spongepowered.asm.mixin.injection.Inject(method = "scheduledTick", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/block/FallingBlock;configureFallingBlockEntity(Lnet/minecraft/entity/FallingBlockEntity;)V", ordinal = 0))
+    private void scheduleTick(final net.minecraft.block.BlockState state, final net.minecraft.server.world.ServerWorld world, final net.minecraft.util.math.BlockPos pos, final Random random, final org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        if (rms.carpet_rms_addition.CarpetRMSAdditionSettings.fallingBlockBackport)
             world.setBlockState(pos, state.getFluidState().getBlockState(), 3);
     }
+    //#endif
 }

--- a/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockMixin.java
+++ b/src/main/java/rms/carpet_rms_addition/mixin/FallingBlockMixin.java
@@ -1,0 +1,22 @@
+package rms.carpet_rms_addition.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.FallingBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import rms.carpet_rms_addition.CarpetRMSAdditionSettings;
+
+import java.util.Random;
+
+@Mixin(FallingBlock.class)
+public abstract class FallingBlockMixin {
+    @Inject(method = "scheduledTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/FallingBlock;configureFallingBlockEntity(Lnet/minecraft/entity/FallingBlockEntity;)V", ordinal = 0))
+    private void scheduleTick(final BlockState state, final ServerWorld world, final BlockPos pos, final Random random, final CallbackInfo ci) {
+        if (CarpetRMSAdditionSettings.fallingBlockBackport)
+            world.setBlockState(pos, state.getFluidState().getBlockState(), 3);
+    }
+}

--- a/src/main/resources/carpet-rms-addition.mixins.json
+++ b/src/main/resources/carpet-rms-addition.mixins.json
@@ -25,5 +25,5 @@
   ],
   "injectors": {
     "defaultRequire": 1
-	}
+  }
 }

--- a/src/main/resources/carpet-rms-addition.mixins.json
+++ b/src/main/resources/carpet-rms-addition.mixins.json
@@ -1,27 +1,29 @@
 {
-	"required": true,
-	"package": "rms.carpet_rms_addition.mixin",
-	"compatibilityLevel": "JAVA_$java_version",
-	"mixins": [
-		"EntityDataObjectMixin",
-		"EntityMixin",
-		"EntityTrackerEntryMixin",
-		"EntityTrackerMixin",
-		"HostileEntityMixin",
-		"ServerPlayNetworkHandlerMixin",
-		"ServerWorldMixin",
-		"SettingsManagerMixin",
-		"SlimeEntityMixin",
-		"SpawnRestrictionMixin",
-		"ThreadedAnvilChunkStorageMixin",
-		"ThrownEntityMixin",
-		"spawners.CatSpawnerMixin",
-		"spawners.PhantomSpawnerMixin",
-		"spawners.PillagerSpawnerMixin",
-		"spawners.WanderingTraderManagerMixin",
-		"spawners.ZombieSiegeManagerMixin"
-	],
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "package": "rms.carpet_rms_addition.mixin",
+  "compatibilityLevel": "JAVA_$java_version",
+  "mixins": [
+    "EntityDataObjectMixin",
+    "EntityMixin",
+    "EntityTrackerEntryMixin",
+    "EntityTrackerMixin",
+    "FallingBlockEntityMixin",
+    "FallingBlockMixin",
+    "HostileEntityMixin",
+    "ServerPlayNetworkHandlerMixin",
+    "ServerWorldMixin",
+    "SettingsManagerMixin",
+    "SlimeEntityMixin",
+    "SpawnRestrictionMixin",
+    "ThreadedAnvilChunkStorageMixin",
+    "ThrownEntityMixin",
+    "spawners.CatSpawnerMixin",
+    "spawners.PhantomSpawnerMixin",
+    "spawners.PillagerSpawnerMixin",
+    "spawners.WanderingTraderManagerMixin",
+    "spawners.ZombieSiegeManagerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
Implemented Carpet feature to make falling blocks mock 1.18.2+ where the original block is destroyed in tile tick instead of when the falling block is ticked for the first time in entity update stage.