### PR TITLE
Fixed an issue where regular expressions in carpet_version could not correctly handle version numbers such as 1.20 and 1.21

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -30,7 +30,7 @@ if (mcVersion < 11700) {
 processResources {
     from "${id}.accesswidener"
     filesMatching('fabric.mod.json') {
-        expand id: id, version: version, minecraft_version: project.name, carpet_version: carpet_core_version.replaceAll(/^\d+\.\d+\.\d+-(\d+\.\d+\.\d+).*$/, '$1'), loader_version: loader_version
+        expand id: id, version: version, minecraft_version: project.name, carpet_version: carpet_core_version.replaceAll(/^\d+\.\d+(?:\.\d+)?-(\d+\.\d+\.\d+).*$/, '$1'), loader_version: loader_version
     }
     filesMatching("${id}.mixins.json") {
         expand java_version: javaCompatibility.ordinal() + 1


### PR DESCRIPTION
Fixed an issue where regular expressions in carpet_version could not correctly handle version numbers such as 1.20 and 1.21

> Tribbie,Trianne and Trinnon I like you!